### PR TITLE
Mobile Map Auto-Pan Changes

### DIFF
--- a/src/components/RoutesComponents/Map/mobileMap.js
+++ b/src/components/RoutesComponents/Map/mobileMap.js
@@ -8,8 +8,9 @@ import houseComplete from "../../../assets/images/MapIcons/houseComplete.svg";
 import houseCompleteSelected from "../../../assets/images/MapIcons/houseCompleteSelected.svg";
 import AlertSnackbar from '../../../components/ReusableComponents/AlertSnackbar'
 import db from '../../FirebaseComponents/Firebase/firebase';
-import { Fab } from '@material-ui/core';
-import GpsFixed from '@material-ui/icons/GpsFixed';
+import { Fab, Tooltip } from '@material-ui/core';
+import GpsFixedIcon from '@material-ui/icons/GpsFixed';
+import GpsNotFixedIcon from '@material-ui/icons/GpsNotFixed';
 
 
 // based on https://developers.google.com/maps/documentation/javascript/adding-a-google-map
@@ -258,7 +259,11 @@ function Map(props) {
       {props.children ? <div style={{ position: 'absolute', overflow: 'hidden', ...innerStyle }}>
         {props.children}
       </div> : null}
-      <Fab color="primary" style={{ position: 'absolute', right: '1rem', bottom: '1rem' }} onClick={resumeTracking}><GpsFixed></GpsFixed></Fab>
+      <Tooltip title={autoPan ? "Your Location" : "Show Your Location"}>
+        <Fab color="primary" style={{ position: 'absolute', right: '1rem', bottom: '1rem' }} onClick={resumeTracking}>
+          {autoPan ? <GpsFixedIcon /> : <GpsNotFixedIcon />}
+        </Fab>
+      </Tooltip>
       {!snackBarState.message || snackBarState.message === "" ? null : <AlertSnackbar
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         open={snackBarState.open}

--- a/src/components/RoutesComponents/Map/mobileMap.js
+++ b/src/components/RoutesComponents/Map/mobileMap.js
@@ -185,7 +185,9 @@ function Map(props) {
     const tracker = trackLocation({
       onSuccess: ({ coords: { latitude: lat, longitude: lng } }) => {
         marker.setPosition({ lat, lng });
-        if (autoPan) map.panTo({ lat, lng });
+        if (autoPan) {
+          map.panTo({ lat, lng });
+        }
       },
       onError: err =>
         setSnackBarState({
@@ -195,17 +197,27 @@ function Map(props) {
       // alert(`Error: ${getPositionErrorMessage(err.code) || err.message}`)
     });
 
-    const dragListener = map.addListener('drag', () => {
-      setAutoPan(false)
-    })
 
     return function cleanup() {
       if (navigator.geolocation) navigator.geolocation.clearWatch(tracker)
-      if (dragListener) google.maps.event.removeListener(dragListener);
       if (marker) marker.setMap(null);
     }
 
   }, [google, map, autoPan]);
+
+  useEffect(() => {
+    if (!map || !google) return;
+    const dragListener = map.addListener('drag', () => {
+      setAutoPan(false)
+    });
+    const zoomListener = map.addListener('zoom_changed', () => {
+      setAutoPan(false)
+    })
+    return function cleanup() {
+      if (dragListener) google.maps.event.removeListener(dragListener);
+      if (zoomListener) google.maps.event.removeListener(zoomListener);
+    }
+  }, [google, map])
 
   useEffect(() => {
     handleSnackBarClose(null, null)
@@ -239,6 +251,7 @@ function Map(props) {
   }
 
   function resumeTracking() {
+    map.setZoom(18);
     setAutoPan(true);
   }
 

--- a/src/components/RoutesComponents/Map/mobileMap.js
+++ b/src/components/RoutesComponents/Map/mobileMap.js
@@ -253,14 +253,14 @@ function Map(props) {
             </a>
           </span> */}
       <div ref={ref} style={{ width: props.width, height: props.height }} />
-      {props.children ? <div style={{ position: 'absolute', overflow: 'hidden', ...innerStyle }}>
-        {props.children}
-      </div> : null}
       <Tooltip title={autoPan ? "Your Location" : "Show Your Location"}>
         <Fab color="primary" style={{ position: 'absolute', right: '1rem', bottom: '1rem' }} onClick={resumeTracking}>
           {autoPan ? <GpsFixedIcon /> : <GpsNotFixedIcon />}
         </Fab>
       </Tooltip>
+      {props.children ? <div style={{ position: 'absolute', overflow: 'hidden', ...innerStyle }}>
+        {props.children}
+      </div> : null}
       {!snackBarState.message || snackBarState.message === "" ? null : <AlertSnackbar
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         open={snackBarState.open}

--- a/src/components/RoutesComponents/Map/mobileMap.js
+++ b/src/components/RoutesComponents/Map/mobileMap.js
@@ -70,7 +70,6 @@ function useFirebaseStreetInfo(assignedRoute) {
 
 function Map(props) {
   const defaultLoc = { lat: 35.9132, lng: -79.0558 }
-  const [lastLoc, setLastLoc] = useState(defaultLoc);
   const { ref, map, google } = useGoogleMaps(
     process.env.REACT_APP_MAPS_API_KEY,
     {
@@ -173,7 +172,6 @@ function Map(props) {
 
     const marker = new google.maps.Marker({
       map: map,
-      position: lastLoc,
       icon: {
         path: google.maps.SymbolPath.CIRCLE,
         scale: 10,
@@ -187,7 +185,6 @@ function Map(props) {
     const tracker = trackLocation({
       onSuccess: ({ coords: { latitude: lat, longitude: lng } }) => {
         marker.setPosition({ lat, lng });
-        setLastLoc({ lat, lng })
         if (autoPan) map.panTo({ lat, lng });
       },
       onError: err =>

--- a/src/components/VolunteerComponents/VolunteerMap/example.js
+++ b/src/components/VolunteerComponents/VolunteerMap/example.js
@@ -31,12 +31,12 @@ function ExampleMap() {
         const unsubscribe = firebase.auth().onAuthStateChanged(async function (user) {
             if (user) {
                 // The code is in routes.js in RouteModels
-                getAssignedRoute(auth.currentUser.uid).then(route => {
-                    setAssignedRoute(route ?? '');
-                })
-                // getAssignedRoute("oGDv0N9Ra0bDj4peHT4EdMZ7Pso1").then(route => {
+                // getAssignedRoute(auth.currentUser.uid).then(route => {
                 //     setAssignedRoute(route ?? '');
                 // })
+                getAssignedRoute("oGDv0N9Ra0bDj4peHT4EdMZ7Pso1").then(route => {
+                    setAssignedRoute(route ?? '');
+                })
             }
         });
         return function cleanup() {

--- a/src/components/VolunteerComponents/VolunteerMap/example.js
+++ b/src/components/VolunteerComponents/VolunteerMap/example.js
@@ -4,7 +4,6 @@ import MobileMap from '../../RoutesComponents/Map/mobileMap';
 import { Paper, ClickAwayListener, Typography, Divider } from '@material-ui/core';
 import { auth } from '../../FirebaseComponents/Firebase/firebase';
 import { getAssignedRoute } from '../../RoutesComponents/ReusableComponents/RouteModels/routes';
-import firebase from 'firebase';
 import VolunteerHouseData from '../VolunteerHouseData';
 
 function ExampleMap() {
@@ -28,15 +27,15 @@ function ExampleMap() {
     })
 
     useEffect(() => {
-        const unsubscribe = firebase.auth().onAuthStateChanged(async function (user) {
+        const unsubscribe = auth.onAuthStateChanged(async function (user) {
             if (user) {
                 // The code is in routes.js in RouteModels
-                // getAssignedRoute(auth.currentUser.uid).then(route => {
-                //     setAssignedRoute(route ?? '');
-                // })
-                getAssignedRoute("oGDv0N9Ra0bDj4peHT4EdMZ7Pso1").then(route => {
+                getAssignedRoute(auth.currentUser.uid).then(route => {
                     setAssignedRoute(route ?? '');
                 })
+                // getAssignedRoute("oGDv0N9Ra0bDj4peHT4EdMZ7Pso1").then(route => {
+                //     setAssignedRoute(route ?? '');
+                // })
             }
         });
         return function cleanup() {


### PR DESCRIPTION
The mobile map no longer auto-pans constantly. When dragging the map or changing the zoom, the auto-panning behavior of the GPS tracking is disabled. The location is still being updated, but the map view is no longer being constantly changed to follow the location marker. Click the Floating Action Button to re-enable the auto-panning feature.

This was implemented to fix the unwanted behavior of the map view being constantly reset to the user location when the user wanted to pan around and explore the area.